### PR TITLE
ADD optional paths to lvm cluster example

### DIFF
--- a/manifests/storage/lvm/lvmcluster.yaml
+++ b/manifests/storage/lvm/lvmcluster.yaml
@@ -11,6 +11,8 @@ spec:
       deviceSelector:
         paths:
         - /dev/sdb
+        optionalPaths:
+        - /dev/sdc
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90


### PR DESCRIPTION
Solves #6 by adding the optionalPaths field to manifest.